### PR TITLE
Add confirm options

### DIFF
--- a/lib/RancherAPI.js
+++ b/lib/RancherAPI.js
@@ -98,10 +98,8 @@ class RancherAPI {
     *   batchSize        Number rancher batch size.
     *   intervalMillis   Number rancher interval between restarts.
     *   startFirst       Bool   rancher start before stop.
-    *
-    * Chain:
-    *
-    *   upgrade => waitForUpgrade => waitForActive
+    *   confirmBefore    Bool   confirm previous upgrade before deploy.
+    *   confirmAfter     Bool   confirm upgrade after deploy.
     *
     *   if successfull returns service object
     *
@@ -117,12 +115,25 @@ class RancherAPI {
         if (typeof options.batchSize === 'undefined') { options.batchSize = 1 }
         if (typeof options.intervalMillis === 'undefined') { options.intervalMillis = 30*1000 }
         if (typeof options.startFirst === 'undefined') { options.startFirst = true }
+        if (typeof options.confirmBefore === 'undefined') { options.confirmBefore = false }
+        if (typeof options.confirmAfter === 'undefined') { options.confirmAfter = true }
         
 
         LOG('Starting deploy for', options.serviceName);
         var self = this;
         return this.getService(options.serviceName).then(function (svc) {
             LOG('Got service', options.serviceName);
+            if (options.confirmBefore && svc.state === 'upgraded') {
+                LOG("Service upgrade pending confirmation. Confirming previous upgrade...");
+                self.post(svc.actions.finishupgrade, {}).then(function(result) {
+                    LOG("Confirm finish upgrade sent.");
+                    // now we wait for service to be active...
+                    self.waitForActive(options.serviceName).then(function (svc) {
+                        return inServiceUpgrade(options);
+                    });
+                });
+            }
+
             if (svc.state !== 'active' && !svc.actions.upgrade) {
                 return ERROR('Service is not in active status. (' + svc.state + '). Cannot proceed.', svc);
             } else if (svc.state !== 'active') {
@@ -152,7 +163,7 @@ class RancherAPI {
         })
         .then(function (result) {
             LOG('Upgrading service...', result.state);
-            return self.waitForUpgrade(options.serviceName);
+            return self.waitForUpgrade(options.serviceName, options.confirmAfter);
         });
     }
     
@@ -161,7 +172,7 @@ class RancherAPI {
      *
      * Waits for upgrade to complete and if successful then triggers a finishupgrade
      */
-    waitForUpgrade (serviceName, startTime) {
+    waitForUpgrade (serviceName, confirmAfter, startTime) {
         var self = this,
             startTime = startTime || Date.now();
         
@@ -174,16 +185,19 @@ class RancherAPI {
             if (svc.state === 'upgrading') {
                 LOG('Service is upgrading, waiting...');
                 return DELAY(self.options.statusCheckFrequency).then(function () { 
-                    return self.waitForUpgrade(serviceName, startTime)
+                    return self.waitForUpgrade(serviceName, confirmAfter, startTime)
                 });
             } else if (svc.state === 'upgraded') {
                 // success!
-                LOG('Service is upgraded. Finishing...');
-                return self.post(svc.actions.finishupgrade, {}).then(function(result) {
-                    LOG('Finish upgrade sent.');
-                    // now we wait for service to be active...
-                    return self.waitForActive(serviceName);
-                });
+                LOG('Service is upgraded!');
+                if (confirmAfter) {
+                    LOG("Confirming upgrade...");
+                    return self.post(svc.actions.finishupgrade, {}).then(function(result) {
+                        LOG("Confirm finish upgrade sent.");
+                        // now we wait for service to be active...
+                        return self.waitForActive(serviceName);
+                    });
+                }
             } else {
                 LOG('unexpected status', svc.state,'Aborting.');
                 return ERROR( "unexpected status ("+ svc.state +") when waiting for upgrade to complete." );
@@ -213,7 +227,7 @@ class RancherAPI {
                     return self.waitForActive(serviceName, startTime);
                 });
             } else {
-                LOG('Upgrade succeded!');
+                LOG('Upgrade confirmed!');
                 return svc;
             };
         });


### PR DESCRIPTION
- Add `confirmAfter` option to be able to avoid automatic confirmation of Rancher upgrades at the end of the release.
- Add `confirmBefore` option to confirm a previous (unconfirmed) Rancher upgrade automatically before the release.